### PR TITLE
Update to work with latest version of Seeed_Arduino_CAN lib (544d2c8e…

### DIFF
--- a/NMEA2000_mcp.h
+++ b/NMEA2000_mcp.h
@@ -30,7 +30,7 @@ based setup. See also NMEA2000 library.
 // CAN_BUS_shield libraries will be originally found on https://github.com/Seeed-Studio/CAN_BUS_Shield
 // That does not work completely with N2k or with Maple mini. So there is developed
 // branch found on https://github.com/ttlappalainen/CAN_BUS_Shield
-#include "mcp_can.h"
+#include "mcp2515_can.h"
 #include "NMEA2000.h"
 #include "N2kMsg.h"
 
@@ -42,7 +42,7 @@ based setup. See also NMEA2000 library.
 class tNMEA2000_mcp : public tNMEA2000
 {
 private:
-  MCP_CAN N2kCAN;
+  mcp2515_can N2kCAN;
   unsigned char N2k_CAN_CS_pin;
   unsigned char N2k_CAN_clockset;
   unsigned char N2k_CAN_int_pin;


### PR DESCRIPTION
…eb5891f41c70c19fdce7cda85211f7ff)

Actually, it's even compatible to the head of Seeed_Arduino_CAN lib as of today: `ef053846591d4bc48aabd4ad82b301fa42d8f92c`

**I did not do much testing!**
I have a Teensy 3.2 + 2x MCP2515 CAN-Shields and I set up one as NMEA2000 sender, the other as receiver (I had to comment `if (CanInUse) return false;` inside `CANOpen()`) for this.

I successfully received NMEA2000 messages sent from the other shield.